### PR TITLE
Admin UI tweaks/fixes

### DIFF
--- a/assets/js/inactive-logout-other.js
+++ b/assets/js/inactive-logout-other.js
@@ -5,10 +5,12 @@
 jQuery(function ($) {
     $('.ina-hacking-select').select2();
     $(".ina-hacking-multi-select").select2({width: '500px', placeholder: "Select Roles"});
+    const EDITOR_HEIGHT = "305px";
 
     //FOR SHOW WARN BOX CHECKBOX
     $('#ina_show_warn_message_only').click(function () {
         if ($(this).prop("checked")) {
+	        $('.show_on_warn_message_enabled iframe').css('height', EDITOR_HEIGHT);
             $('.show_on_warn_message_enabled').show();
         } else {
             $('.show_on_warn_message_enabled').hide();
@@ -39,6 +41,7 @@ jQuery(function ($) {
             }
         } else {
             $('.show_on_enable_redirect_link').hide();
+            $('.ina_hide_message_content iframe').css('height', EDITOR_HEIGHT);
             $('.ina_hide_message_content').show();
             $('.show_cutom_redirect_textfield').hide();
         }

--- a/assets/js/inactive-logout-other.js
+++ b/assets/js/inactive-logout-other.js
@@ -7,12 +7,6 @@ jQuery(function ($) {
     $(".ina-hacking-multi-select").select2({width: '500px', placeholder: "Select Roles"});
 
     //FOR SHOW WARN BOX CHECKBOX
-    if ($('#ina_show_warn_message_only').is(":checked")) {
-        $('.show_on_warn_message_enabled').show();
-    } else {
-        $('.show_on_warn_message_enabled').hide();
-    }
-
     $('#ina_show_warn_message_only').click(function () {
         if ($(this).prop("checked")) {
             $('.show_on_warn_message_enabled').show();
@@ -24,12 +18,6 @@ jQuery(function ($) {
     // Add Color Picker to all inputs that have 'color-field' class
     $('.ina_color_picker').wpColorPicker();
 
-    if ($('input[name="ina_full_overlay"]').is(":checked")) {
-        $('.ina_colorpicker_show').show();
-    } else {
-        $('.ina_colorpicker_show').hide();
-    }
-
     $('input[name="ina_full_overlay"]').click(function () {
         if ($(this).prop("checked")) {
             $('.ina_colorpicker_show').show();
@@ -39,21 +27,6 @@ jQuery(function ($) {
     });
 
     //FOR REDIRECT CHECKBOX
-    if ($('#ina_enable_redirect_link').is(":checked")) {
-        $('.show_on_enable_redirect_link').show();
-        $('.ina_hide_message_content').hide();
-
-        if ($('select[name=ina_redirect_page]').val() == "custom-page-redirect") {
-            $('.show_cutom_redirect_textfield').show();
-        } else {
-            $('.show_cutom_redirect_textfield').hide();
-        }
-    } else {
-        $('.show_on_enable_redirect_link').hide();
-        $('.ina_hide_message_content').show();
-        $('.show_cutom_redirect_textfield').hide();
-    }
-
     $('#ina_enable_redirect_link').click(function () {
         if ($(this).prop("checked")) {
             $('.show_on_enable_redirect_link').show();
@@ -72,12 +45,6 @@ jQuery(function ($) {
     });
 
     //FOR ADV SETTINGS MULTI ROLE ENABLE CHECKBOX
-    if ($('#ina_enable_different_role_timeout').is(":checked")) {
-        $('.ina-multi-role-table, .hide-description-ina').show();
-    } else {
-        $('.ina-multi-role-table, .hide-description-ina').hide();
-    }
-
     $('#ina_enable_different_role_timeout').click(function () {
         if ($(this).prop("checked")) {
             $('.ina-multi-role-table, .hide-description-ina').show();

--- a/src/class-inactive-logout-helpers.php
+++ b/src/class-inactive-logout-helpers.php
@@ -194,4 +194,20 @@ class Inactive_Logout_Helpers {
 
 		return $result;
 	}
+	/**
+	 * Handle display of wp-admin form elements if option is enabled/disabled on pageload
+	 *
+	 * @author  Patrick Strube
+	 * @since   1.7.9
+	 *
+	 * @param bool $option Checked or unchecked option to evaluate
+	 * @return string
+	 */
+	 public function ina_set_element_display( $option ){
+		if( !empty( $option ) ){
+			return "display:table-row;";
+		} else {
+			return "display:none;";
+		}
+	 }
 }

--- a/views/tabs/tpl-inactive-logout-advanced.php
+++ b/views/tabs/tpl-inactive-logout-advanced.php
@@ -112,7 +112,7 @@
            style="float:right;">
 			<?php
 			// translators: Disable string.
-			printf( esc_html__( 'Note: %s is used for disabling inactive logout functionality to that specific user.', 'inactive-logout' ), esc_html( $bold_string ) );
+			printf( esc_html__( 'Note: %s is used for disabling inactive logout functionality to that specific user.', 'inactive-logout' ), $bold_string );
 			?>
         </p>
 	<?php } ?>

--- a/views/tabs/tpl-inactive-logout-advanced.php
+++ b/views/tabs/tpl-inactive-logout-advanced.php
@@ -21,8 +21,8 @@
                 <p class="description"><?php esc_html_e( 'This will enable multi-user role timeout functionality.', 'inactive-logout' ); ?></p>
             </td>
         </tr>
-        <tr class="ina-multi-role-table">
-            <th scope="row"><label for="idle_timeout"><?php esc_html_e( 'Enable Multi-User Feature', 'inactive-logout' ); ?></label></th>
+        <tr class="ina-multi-role-table" style="<?php echo $this->helper->ina_set_element_display( $ina_multiuser_timeout_enabled ); ?>">
+	        <th scope="row"><label for="idle_timeout"><?php esc_html_e( 'Enable Multi-User Feature', 'inactive-logout' ); ?></label></th>
             <td>
                 <select class="ina-hacking-multi-select" id="ina_definetime_specific_userroles" multiple="multiple" name="ina_multiuser_roles[]">
 					<?php

--- a/views/tabs/tpl-inactive-logout-basic.php
+++ b/views/tabs/tpl-inactive-logout-basic.php
@@ -27,14 +27,21 @@
                 <i><?php esc_html_e( 'Minute(s)', 'inactive-logout' ); ?></i>
             </td>
         </tr>
-        <tr class="ina_hide_message_content">
+        <tr class="ina_hide_message_content" style="<?php echo $this->helper->ina_set_element_display( empty( $ina_enable_redirect ) ); ?>">
             <th scope="row"><label for="idle_timeout"><?php esc_html_e( 'Idle Message Content', 'inactive-logout' ); ?></label></th>
             <td>
 				<?php
+				if( ! empty( $ina_enable_redirect ) ){
+					$msg_editor_style = "<style> .wp-idle_message_text-wrap iframe { display: none; }</style>";
+				} else {
+					$msg_editor_style = "";
+				}
+				
 				$settings        = array(
 					'media_buttons' => false,
 					'teeny'         => true,
 					'textarea_rows' => 15,
+					'editor_css' => $msg_editor_style,
 				);
 				$message_content = get_option( '__ina_logout_message' );
 				$content         = $message_content ? $message_content : null;
@@ -72,14 +79,21 @@
                 <p class="description ina-warn-info"><strong><?php esc_html_e( 'Please note ! Multi role timeout feature will not work when this setting is enabled. Similarly, idle Message Content will be ignored and replaced with this content.', 'inactive-logout' ); ?></strong></p>
             </td>
         </tr>
-        <tr class="show_on_warn_message_enabled">
+        <tr class="show_on_warn_message_enabled" style="<?php echo $this->helper->ina_set_element_display( $ina_warn_message_enabled ); ?>">
             <th scope="row"><label for="ina_show_warn_message"><?php esc_html_e( 'Warn Message Content', 'inactive-logout' ); ?></label></th>
             <td>
 				<?php
+				if( ! empty( $ina_warn_message_enabled ) ){
+					$warn_style = "<style> .wp-ina_show_warn_message-wrap iframe { display: none; }</style>";
+				} else {
+					$warn_style = "";
+				}
+				
 				$settings_warn        = array(
 					'media_buttons' => false,
 					'teeny'         => true,
 					'textarea_rows' => 15,
+					'editor_css' => $warn_style,
 				);
 				$__ina_warn_message   = get_option( '__ina_warn_message' );
 				$content_warn_message = $__ina_warn_message ? $__ina_warn_message : null;
@@ -102,10 +116,10 @@
                 <p class="description"><?php esc_html_e( 'If not checked then user will be logged out to login screen after timeout.', 'inactive-logout' ); ?></p>
             </td>
         </tr>
-        <tr class="show_on_enable_redirect_link" style="display:none;">
+        <tr class="show_on_enable_redirect_link" style="<?php echo $this->helper->ina_set_element_display( $ina_enable_redirect ); ?>">
             <th scope="row"><label for="ina_redirect_page"><?php esc_html_e( 'Redirect Page', 'inactive-logout' ); ?></label></th>
             <td>
-                <select name="ina_redirect_page" class="regular-text ina-hacking-select">
+                <select name="ina_redirect_page" class="regular-text ina-hacking-select" style="appearance:none; -webkit-appearance:none; -moz-appearance:none;">
                     <option value="custom-page-redirect"><?php esc_html_e( 'External Page Redirect', 'inactive-logout' ); ?></option>
 					<?php
 					$ina_helpers = Inactive_Logout_Helpers::instance();
@@ -151,7 +165,7 @@
                 <p class="description"><?php esc_html_e( 'Select a page to redirect to after session timeout and clicking OK.', 'inactive-logout' ); ?></p>
             </td>
         </tr>
-        <tr class="show_cutom_redirect_textfield" <?php echo ( ( ! empty( $ina_redirect_page_link ) && 'custom-page-redirect' === $ina_redirect_page_link ) ) ? false : 'style=display:none;'; ?> >
+        <tr class="show_cutom_redirect_textfield" <?php echo ( ! empty( $ina_enable_redirect ) && ( ! empty( $ina_redirect_page_link ) && 'custom-page-redirect' === $ina_redirect_page_link ) ) ? false : 'style=display:none;'; ?> >
             <th scope="row"><label for="custom_redirect_text_field"><?php esc_html_e( 'Custom URL Redirect', 'inactive-logout' ); ?></label></th>
             <td>
                 <input name="custom_redirect_text_field" type="url" id="custom_redirect_text_field" class="regular-text code" value="<?php echo ( ! empty( $custom_redirect_text_field ) ) ? esc_attr( $custom_redirect_text_field ) : false; ?>">


### PR DESCRIPTION
Fixes:
4a9b7e6 - Raw HTML output in message under user role table on 'Advanced Management' tab. 

5875e9d - Admin form elements are initially shown or hidden using PHP instead of JavaScript. Using JS to initially hide or show the elements can cause them to appear on the page for a split second before being hidden.

d3b292c - Consistent height given to wp_editor elements when they are shown after clicking the checkbox to enable them. If these elements are visible on pageload, they have a height of 305px but if they are hidden during pageload and then shown/enabled, they only have a height of ~100px.